### PR TITLE
Feature/7 remove log output in contract

### DIFF
--- a/packages/contract/contracts/Messenger.sol
+++ b/packages/contract/contracts/Messenger.sol
@@ -2,7 +2,6 @@
 
 pragma solidity ^0.8.17;
 
-import "hardhat/console.sol";
 import "./Ownable.sol";
 
 contract Messenger is Ownable {
@@ -37,8 +36,6 @@ contract Messenger is Ownable {
     event NumOfPendingLimitsChanged(uint256 limits);
 
     constructor(uint256 _numOfPendingLimits) payable {
-        console.log("Here is my first smart contract!");
-
         ownable();
 
         numOfPendingLimits = _numOfPendingLimits;
@@ -63,13 +60,6 @@ contract Messenger is Ownable {
 
         // 保留中のメッセージの数をインクリメントします。
         _numOfPendingAtAddress[_receiver] += 1;
-
-        console.log(
-            "%s posts text:[%s] token:[%d]",
-            msg.sender,
-            _text,
-            msg.value
-        );
 
         _messagesAtAddress[_receiver].push(
             Message(

--- a/packages/contract/test/Messenger.ts
+++ b/packages/contract/test/Messenger.ts
@@ -194,7 +194,7 @@ describe('Messenger', function () {
   });
 
   describe('Deny', function () {
-    it('Should emit an event on accept', async function () {
+    it('Should emit an event on deny', async function () {
       const { messenger, otherAccount } = await loadFixture(deployContract);
       const test_deposit = 1;
 

--- a/packages/contract/test/Messenger.ts
+++ b/packages/contract/test/Messenger.ts
@@ -1,3 +1,4 @@
+import { anyValue } from '@nomicfoundation/hardhat-chai-matchers/withArgs';
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import { Overrides } from 'ethers';
@@ -57,20 +58,28 @@ describe('Messenger', function () {
     it('Should emit an event on change limits', async function () {
       const { messenger } = await loadFixture(deployContract);
 
-      await expect(messenger.changeNumOfPendingLimits(10)).to.emit(
-        messenger,
-        'NumOfPendingLimitsChanged',
-      );
+      await expect(messenger.changeNumOfPendingLimits(10))
+        .to.emit(messenger, 'NumOfPendingLimitsChanged')
+        .withArgs(10);
     });
   });
 
   describe('Post', function () {
     it('Should emit an event on post', async function () {
-      const { messenger, otherAccount } = await loadFixture(deployContract);
+      const { messenger, owner, otherAccount } = await loadFixture(
+        deployContract,
+      );
 
-      await expect(
-        messenger.post('text', otherAccount.address, { value: 1 }),
-      ).to.emit(messenger, 'NewMessage');
+      await expect(messenger.post('text', otherAccount.address, { value: 1 }))
+        .to.emit(messenger, 'NewMessage')
+        .withArgs(
+          owner.address,
+          otherAccount.address,
+          1,
+          anyValue,
+          'text',
+          true,
+        );
     });
 
     it('Should send the correct amount of tokens', async function () {
@@ -137,10 +146,9 @@ describe('Messenger', function () {
       });
 
       const first_index = 0;
-      await expect(messenger.connect(otherAccount).accept(first_index)).to.emit(
-        messenger,
-        'MessageConfirmed',
-      );
+      await expect(messenger.connect(otherAccount).accept(first_index))
+        .to.emit(messenger, 'MessageConfirmed')
+        .withArgs(otherAccount.address, first_index);
     });
 
     it('isPending must be changed', async function () {
@@ -195,10 +203,9 @@ describe('Messenger', function () {
       });
 
       const first_index = 0;
-      await expect(messenger.connect(otherAccount).deny(first_index)).to.emit(
-        messenger,
-        'MessageConfirmed',
-      );
+      await expect(messenger.connect(otherAccount).deny(first_index))
+        .to.emit(messenger, 'MessageConfirmed')
+        .withArgs(otherAccount.address, first_index);
     });
 
     it('isPending must be changed', async function () {


### PR DESCRIPTION
## 変更内容

コントラクト内に定義されていた`console.log`を削除しました。

以下は`yarn contract test`を実行した際の出力です。

### 修正前
![Screenshot 2023-11-25 at 18 17 36](https://github.com/unchain-tech/AVAX-Messenger/assets/60546319/5dfc1a39-9c46-4218-a3ed-e431a3e1fbdc)

### 修正後
![3_1_2](https://github.com/unchain-tech/AVAX-Messenger/assets/60546319/0f9ecb87-7f2e-4cab-a0f3-2e8556d2d69d)
